### PR TITLE
Empty vtt cue is valid

### DIFF
--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -93,15 +93,10 @@ class WebVTTReader(BaseReader):
 
             elif '' == line:
                 if found_timing:
-                    if not nodes:
-                        raise CaptionReadSyntaxError(
-                            'Cue without content. (line %d)' % timing_line)
-                    else:
-                        found_timing = False
-                        caption = Caption(
-                            start, end, nodes, layout_info=layout_info)
-                        captions.append(caption)
-                        nodes = []
+                    found_timing = False
+                    caption = Caption(start, end, nodes, layout_info=layout_info)
+                    captions.append(caption)
+                    nodes = []
             else:
                 if found_timing:
                     if nodes:

--- a/tests/test_webvtt.py
+++ b/tests/test_webvtt.py
@@ -127,16 +127,6 @@ class WebVTTReaderTestCase(unittest.TestCase):
 
     def test_invalid_files(self):
         self.assertRaises(
-            CaptionReadSyntaxError,
-            WebVTTReader().read,
-            ("\nNOTE Cues without text are invalid.\n"
-                "00:00:20.000 --> 00:00:30.000\n"
-                "\n"
-                "00:00:40.000 --> 00:00:50.000\n"
-                "foo bar baz\n")
-        )
-
-        self.assertRaises(
             CaptionReadError,
             WebVTTReader(ignore_timing_errors=False).read,
             ("00:00:20.000 --> 00:00:10.000\n"


### PR DESCRIPTION
@udemy/team-t my PR to the source library has been sitting idle with no sign of reply for several months.. and the last commit to pycaption was 11 months ago, so sadly looks like we should fork it.. for now.

Let's see, we may even go and address more of the issues on pbs/pycaption and become official maintainers.

The actual PR is about: According to vtt spec, a cue can consist of zero or more cue components https://www.w3.org/TR/webvtt1/#cue-text - so an empty cue should really not be raising an error.