### PR TITLE
Do not make assumptions about requiring text in the main Caption class

### DIFF
--- a/pycaption/base.py
+++ b/pycaption/base.py
@@ -181,8 +181,6 @@ class Caption(object):
         if not isinstance(end, Number):
             raise CaptionReadTimingError("Captions must be initialized with a"
                                          " valid end time")
-        if not nodes:
-            raise CaptionReadError("Node list cannot be empty")
         self.start = start
         self.end = end
         self.nodes = nodes


### PR DESCRIPTION
@udemy/team-t another error when trying to parse a VTT with empty cues - the underlying Caption class was making assumptions about the text being a requirement. Removing that from here and letting individual implementation validators take care of that instead.

Tested and now works for sure for VTT :D