### PR TITLE
Python 3.7 upgrade preparation: Remove enum34 dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
     - 3.5
+    - 3.7
 
 script: python setup.py test
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ py-caption
 to read content into a CaptionSet object, and then use one of the Writers to
 output the CaptionSet into captions of your desired format.
 
-Tested with Python 3.5.
+Tested with Python 3.5 and 3.7.
 
 For details, see the `documentation <http://pycaption.readthedocs.org>`__.
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ dependencies = [
     'lxml>=3.2.3',
     'cssutils>=0.9.10',
     'future',
-    'enum34',
     'six>=1.9.0'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,12 @@ dependencies = [
     'lxml==3.6.1',
     'cssutils>=1.0.1',
     'future',
-    'enum34',
     'six>=1.9.0'
 ]
 
 setup(
     name='pycaption',
-    version='1.1.0.ud4',
+    version='1.1.0.ud5',
     description='Closed caption converter',
     long_description=open(README_PATH).read(),
     author='Joe Norton',

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ README_PATH = os.path.join(
     'README.rst')
 
 dependencies = [
-    'beautifulsoup4>=4.2.1,<=4.6.0',
-    'lxml>=3.5, < 4.0',
+    'beautifulsoup4>=4.9.0',
+    'lxml>=4.5.2',
     'cssutils>=1.0.1',
     'future',
     'six>=1.9.0'

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ dependencies = [
     'lxml>=3.2.3',
     'cssutils>=0.9.10',
     'future',
+    'enum34',
     'six>=1.9.0'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ README_PATH = os.path.join(
     'README.rst')
 
 dependencies = [
-    'beautifulsoup4>=4.2.1,<=4.6.0',
-    'lxml==4.4.3',
+    'beautifulsoup4>=4.8.0',
+    'lxml>=4.5.2',
     'cssutils>=1.0.1',
     'future',
     'six>=1.9.0'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README_PATH = os.path.join(
 
 dependencies = [
     'beautifulsoup4>=4.2.1,<=4.6.0',
-    'lxml==4.5.2',
+    'lxml==4.4.3',
     'cssutils>=1.0.1',
     'future',
     'six>=1.9.0'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README_PATH = os.path.join(
     'README.rst')
 
 dependencies = [
-    'beautifulsoup4>=4.8.0',
+    'beautifulsoup4>=4.2.1,<=4.6.0',
     'lxml>=3.5, < 4.0',
     'cssutils>=1.0.1',
     'future',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README_PATH = os.path.join(
 
 dependencies = [
     'beautifulsoup4>=4.2.1,<=4.6.0',
-    'lxml==3.6.1',
+    'lxml==4.5.2',
     'cssutils>=1.0.1',
     'future',
     'six>=1.9.0'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README_PATH = os.path.join(
 
 dependencies = [
     'beautifulsoup4>=4.8.0',
-    'lxml>=4.4.0',
+    'lxml>=4.3.5',
     'cssutils>=1.0.1',
     'future',
     'six>=1.9.0'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README_PATH = os.path.join(
 
 dependencies = [
     'beautifulsoup4>=4.8.0',
-    'lxml>=4.3.5',
+    'lxml>=3.5, < 4.0',
     'cssutils>=1.0.1',
     'future',
     'six>=1.9.0'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README_PATH = os.path.join(
 
 dependencies = [
     'beautifulsoup4>=4.8.0',
-    'lxml>=4.5.2',
+    'lxml>=4.4.0',
     'cssutils>=1.0.1',
     'future',
     'six>=1.9.0'

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py35, py37
 [testenv]
 deps=
-    beautifulsoup4==4.8
+    beautifulsoup4==4.6
     lxml==3.6.1
     cssutils==1.0.1
 commands=python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35
+envlist = py35, py37
 [testenv]
 deps=
     beautifulsoup4==4.4

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,6 @@ envlist = py35, py37
 [testenv]
 deps=
     beautifulsoup4==4.8
-    lxml==4.4.0
+    lxml==4.3.5
     cssutils==1.0.1
 commands=python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py35, py37
 [testenv]
 deps=
-    beautifulsoup4==4.6
-    lxml==3.6.1
+    beautifulsoup4==4.9.1
+    lxml==4.5.2
     cssutils==1.0.1
 commands=python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,6 @@ envlist = py35, py37
 [testenv]
 deps=
     beautifulsoup4==4.8
-    lxml==4.5.2
+    lxml==4.4.0
     cssutils==1.0.1
 commands=python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,6 @@ envlist = py35, py37
 [testenv]
 deps=
     beautifulsoup4==4.8
-    lxml==4.3.5
+    lxml==3.6.1
     cssutils==1.0.1
 commands=python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py35, py37
 [testenv]
 deps=
-    beautifulsoup4==4.4
-    lxml==3.6.1
+    beautifulsoup4==4.8
+    lxml==4.5.2
     cssutils==1.0.1
 commands=python setup.py test


### PR DESCRIPTION
This PR removes a dependency on enum34 which interferes with `line-profiler` lib install, and which is not required for Python versions since 3.4 when it was included in the standard library (see https://www.python.org/dev/peps/pep-0435/). I verified that the standard library version is being used when importing `Enum` and so its removal should not have any side effects given that we are currently using Python 3.5.