### PR TITLE
PEP 440 compliance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ dependencies = [
 
 setup(
     name='pycaption',
-    version='1.1.0.ud4',
+    version='1.1.0ud4',
     description='Closed caption converter',
     long_description=open(README_PATH).read(),
     author='Joe Norton',


### PR DESCRIPTION
The current version is incompatible, making installs with poetry fail with PEP440 errors as a result.

https://peps.python.org/pep-0440/#examples-of-compliant-version-schemes